### PR TITLE
Model creation and Factories build out

### DIFF
--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Conversation extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id1',
+        'user_id2',
+        'last_message_id',
+    ];
+}

--- a/app/Models/Conversation.php
+++ b/app/Models/Conversation.php
@@ -14,4 +14,17 @@ class Conversation extends Model
         'user_id2',
         'last_message_id',
     ];
+
+    public function lastMessage()
+    {
+        return $this->belongsTo(Message::class, 'last_message_id');
+    }
+    public function user1()
+    {
+        return $this->belongsTo(User::class, 'user_id1');
+    }
+    public function user2()
+    {
+        return $this->belongsTo(User::class, 'user_id2');
+    }
 }

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Group extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'owner_id',
+        'last_message_id',
+    ];
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -15,4 +15,17 @@ class Group extends Model
         'owner_id',
         'last_message_id',
     ];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class, 'group_users');
+    }
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+    public function owner()
+    {
+        return $this->belongsTo(User::class);
+    }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -16,4 +16,21 @@ class Message extends Model
         'group_id',
         'receiver_id',
     ];
+
+    public function sender()
+    {
+        return $this->belongsTo(User::class, 'sender_id');
+    }
+    public function receiver()
+    {
+        return $this->belongsTo(User::class, 'receiver_id');
+    }
+    public function group()
+    {
+        return $this->belongsTo(Group::class);
+    }
+    public function attachments()
+    {
+        return $this->belongsTo(MessageAttachment::class);
+    }
 }

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+
+    protected $fillable = [
+        'mesage',
+        'sender_id',
+        'group_id',
+        'receiver_id',
+    ];
+}

--- a/app/Models/MessageAttachment.php
+++ b/app/Models/MessageAttachment.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MessageAttachment extends Model
+{
+    use HasFactory;
+
+
+    protected $fillable = [
+        'message_id',
+        'name',
+        'path',
+        'mime',
+        'size',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -47,4 +47,9 @@ class User extends Authenticatable
             'password' => 'hashed',
         ];
     }
+
+    public function groups()
+    {
+        return $this->belongsToMany(Group::class, 'group_users');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -17,9 +17,12 @@ class User extends Authenticatable
      * @var array<int, string>
      */
     protected $fillable = [
+        'avatar',
         'name',
         'email',
+        'email_verified_at',
         'password',
+        'is_admin'
     ];
 
     /**

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Group>
+ */
+class GroupFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name,
+            'description' => $this->faker->sentence,
+        ];
+    }
+}

--- a/database/factories/MessageFactory.php
+++ b/database/factories/MessageFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Message>
+ */
+class MessageFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $senderId = $this->faker->randomElement([0, 1]);
+        if ($senderId === 0) {
+            $senderId = $this->faker->randomElement(\App\Models\User::where('id', '!=', 1)->pluck('id')->toArray());
+            $receiverId = 1;
+        } else {
+            $receiverId = $this->faker->randomElement(\App\Models\User::pluck('id')->toArray());
+        }
+
+        $groupId = null;
+        if ($this->faker->boolean(50)) {
+            $groupId = $this->faker->randomElement(\App\Models\Group::pluck('id')->toArray());
+            $group = \App\Models\Group::find($groupId);
+            $senderId = $this->faker->randomElement($group->users->pluck('id')->toArray());
+            $receiverId = null;
+        }
+
+
+        return [
+            'sender_id' => $senderId,
+            'receiver_id' => $receiverId,
+            'group_id' => $groupId,
+            'message' => $this->faker->realText(200),
+            'created_at' => $this->faker->dateTimeBetween('-1 year', 'now'),
+        ];
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -15,9 +15,12 @@ return new class extends Migration
             $table->id();
             $table->string('name');
             $table->string('email')->unique();
+            $table->string('avatar')->nullable();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
             $table->rememberToken();
+            $table->boolean('is_admin')->default(false);
+            $table->timestamp('blocked_at')->nullable();
             $table->timestamps();
         });
 

--- a/database/migrations/2024_08_01_211452_create_groups_table.php
+++ b/database/migrations/2024_08_01_211452_create_groups_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('groups', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->longText('description')->nullable();
+            $table->foreignId('owner_id')->constrained('users')->onDelete('cascade');
+
+            $table->timestamps();
+        });
+
+        Schema::create('group_users', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('group_id')->constrained('groups')->onDelete('cascade');
+            $table->foreignId('user_id')->constrained('users')->onDelete('cascade');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('group_users');
+        Schema::dropIfExists('groups');
+    }
+};

--- a/database/migrations/2024_08_01_211521_create_conversations_table.php
+++ b/database/migrations/2024_08_01_211521_create_conversations_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('conversations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id1')->constrained('users');
+            $table->foreignId('user_id2')->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('conversations');
+    }
+};

--- a/database/migrations/2024_08_01_211530_create_messages_table.php
+++ b/database/migrations/2024_08_01_211530_create_messages_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->longText('message')->nullable();
+            // this enables just sending a photo
+            $table->foreignId('sender_id')->constrained('users');
+            $table->foreignId('receiver_id')->nullable()->constrained('users');
+            $table->foreignId('group_id')->nullable()->constrained('groups');
+            $table->foreignId('conversation_id')->nullable()->constrained('conversations');
+            $table->timestamps();
+        });
+
+        Schema::table('groups', function (Blueprint $table) {
+            $table->foreignId('last_message_id')->nullable()->constrained('messages');
+        });
+
+        Schema::table('conversations', function (Blueprint $table) {
+            $table->foreignId('last_message_id')->nullable()->constrained('messages');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('messages');
+    }
+};

--- a/database/migrations/2024_08_01_211542_create_message_attachments_table.php
+++ b/database/migrations/2024_08_01_211542_create_message_attachments_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('message_attachments', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained('messages');
+            $table->string('name', 255);
+            $table->string('path', 1024);
+            $table->string('mime', 255);
+            $table->integer('size');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('message_attachments');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,8 +2,12 @@
 
 namespace Database\Seeders;
 
+use App\Models\Conversation;
+use App\Models\Message;
+use App\Models\Group;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -13,11 +17,44 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
-
         User::factory()->create([
-            'name' => 'Test User',
-            'email' => 'test@example.com',
+            'name' => 'Kimi Raikkonen',
+            'email' => 'theiceman@finmail.com',
+            'password' => bcrypt('password'),
+            'is_admin' => true
         ]);
+        User::factory()->create([
+            'name' => 'Sebastian Vettel',
+            'email' => 'seb@vettel.de',
+            'password' => bcrypt('password'),
+        ]);
+
+        User::factory(10)->create();
+
+        for ($i = 0; $i < 5; $i++) {
+            $group = Group::factory()->create([
+                'owner_id' => 1
+            ]);
+
+            $users = User::inRandomOrder()->limit(rand(2,5))->pluck('id');
+            $group->users()->attach(array_unique([1, ...$users]));
+        }
+
+        Message::factory(1000)->create();
+        $messages = Message::whereNull('group_id')->orderBy('created_at')->get();
+
+        $conversations = $messages->groupBy(function ($message) {
+            return collect([$message->sender_id, $message->receiver_id])->sort()->implode('_');
+        })->map(function ($groupedMessages) {
+            return [
+                'user_id1' => $groupedMessages->first()->sender_id,
+                'user_id2' => $groupedMessages->first()->sender_id,
+                'last_message_id' => $groupedMessages->last()->id,
+                'created_at' => new Carbon(),
+                'updated_at' => new Carbon(),
+            ];
+        })->values();
+
+        Conversation::insertOrIgnore($conversations->toArray());
     }
 }


### PR DESCRIPTION
This PR implements the models needed to store conversations and messages in the database. This also implements the factories to create mock data to work and test with moving forward, and also subsequently creates the migrations needed for things to work.

```
php artisan migrate:fresh --seed

  Dropping all tables ............................................................................................................ 126.70ms DONE

   INFO  Preparing database.

  Creating migration table ........................................................................................................ 44.68ms DONE

   INFO  Running migrations.

  0001_01_01_000000_create_users_table ............................................................................................ 70.80ms DONE
  0001_01_01_000001_create_cache_table ............................................................................................. 7.84ms DONE
  0001_01_01_000002_create_jobs_table ............................................................................................. 34.09ms DONE
  2024_08_01_211452_create_groups_table ........................................................................................... 44.60ms DONE
  2024_08_01_211521_create_conversations_table .................................................................................... 25.47ms DONE
  2024_08_01_211530_create_messages_table ......................................................................................... 92.64ms DONE
  2024_08_01_211542_create_message_attachments_table .............................................................................. 15.44ms DONE


   INFO  Seeding database.

```